### PR TITLE
Fix test case title / comment to match polynomial used

### DIFF
--- a/src/test/java/edu/ucsb/cs56/polynomial/PolynomialTest.java
+++ b/src/test/java/edu/ucsb/cs56/polynomial/PolynomialTest.java
@@ -732,11 +732,11 @@ public class PolynomialTest
   /**
      test the lowToHigh function that converts a highToLow int array of
      coefficients into a lowToHigh int array of coefficients,
-     using the polynomial <code> -10x^4 - 20x^3 -40</code>
+     using the polynomial <code> -10x^4 - 20x^3 -40x</code>
      @see Polynomial#lowToHigh
    */
   @Test
-  public void test_lowToHigh_neg10x4_minus20x3_minus40() {
+  public void test_lowToHigh_neg10x4_minus20x3_minus40x() {
     // polynomial: -10x^4 - 20x^3 -40x
     int [] coeffsHighToLow = new int [] {0, -10, -20, 0, -40, 0};
     int [] actual = Polynomial.lowToHigh(coeffsHighToLow);


### PR DESCRIPTION
The test case `test_lowToHigh_neg10x4_minus20x3_minus40` uses the polynomial `-10x^4 - 20x^3 -40x` instead of `-10x^4 - 20x^3 -40`. This change fixes the title of the test and Javadoc documentation to reflect the correct polynomial.